### PR TITLE
Yaml key variable expansion

### DIFF
--- a/lib/config_hound/interpolation.rb
+++ b/lib/config_hound/interpolation.rb
@@ -47,7 +47,7 @@ module ConfigHound
 
       def expand_hash(input)
         input.each_with_object({}) do |(k,v), a|
-          a[k] = expand(v)
+          a[expand(k)] = expand(v)
         end
       end
 

--- a/spec/features/expansion_spec.rb
+++ b/spec/features/expansion_spec.rb
@@ -16,6 +16,38 @@ describe ConfigHound, "expansion" do
     expect(config["address"]).to eq("host:5678")
   end
 
+  context "with key expansion" do
+
+    given_resource "config-with-key-expansion.yml", %{
+      var:
+        account_id: "123"
+      <(var.account_id)>: value
+    }
+
+    let(:config) { ConfigHound.load("config-with-key-expansion.yml", :expand_refs => true) }
+
+    it "expands key references" do
+      expect(config["123"]).to eq("value")
+    end
+
+  end
+
+  context "with key and value expansion" do
+
+    given_resource "config-with-key-and-value-expansion.yml", %{
+      var:
+        account_id: "123"
+        port: 5678
+      <(var.account_id)>: host:<(var.port)>
+    }
+    let(:config) { ConfigHound.load("config-with-key-and-value-expansion.yml", :expand_refs => true) }
+    
+    it "expands key references" do
+      expect(config["123"]).to eq("host:5678")
+    end
+
+  end
+
   context "with overrides" do
 
     given_resource "overrides.yml", %{


### PR DESCRIPTION
Via @dtbell91

> It would save me a bunch of copying and pasting to be able to expand references in key names as well as values.
> 
> e.g.
> 
> ```
> # myapp.yml
> ---
> include: common.yml
> var:
>   account_id: 123
> 
> # common.yml
> ---
> <(var.account_id)>:
>   foo: bar
> ```