### PR TITLE
Duplicate key warnings

### DIFF
--- a/lib/config_hound/loader.rb
+++ b/lib/config_hound/loader.rb
@@ -8,9 +8,11 @@ module ConfigHound
     DEFAULT_INCLUDE_KEY = "_include"
 
     attr_accessor :include_key
+    attr_accessor :allow_duplicate_keys
 
     def initialize(options = {})
       @include_key = DEFAULT_INCLUDE_KEY
+      @allow_duplicate_keys = true
       options.each do |k, v|
         public_send("#{k}=", v)
       end
@@ -26,7 +28,7 @@ module ConfigHound
     def load_source(source)
       return source if source.is_a?(Hash)
       resource = Resource[source]
-      raw_data = resource.load
+      raw_data = resource.load(allow_duplicate_keys: allow_duplicate_keys)
       includes = Array(raw_data.delete(include_key))
       included_resources = includes.map do |relative_path|
         resource.resolve(relative_path)

--- a/lib/config_hound/parser.rb
+++ b/lib/config_hound/parser.rb
@@ -1,3 +1,4 @@
+require 'config_hound/parser/duplicate_key_error'
 require 'config_hound/parser/json'
 require 'config_hound/parser/toml'
 require 'config_hound/parser/yaml'

--- a/lib/config_hound/parser.rb
+++ b/lib/config_hound/parser.rb
@@ -1,5 +1,8 @@
-module ConfigHound
+require 'config_hound/parser/json'
+require 'config_hound/parser/toml'
+require 'config_hound/parser/yaml'
 
+module ConfigHound
   class Parser
 
     def self.parse(*args)
@@ -7,30 +10,10 @@ module ConfigHound
     end
 
     def parse(raw, format)
-      parse_method = "parse_#{format}"
-      raise "unknown format: #{format}" unless respond_to?(parse_method, true)
-      send(parse_method, raw)
-    end
-
-    protected
-
-    def parse_yaml(raw)
-      require "yaml"
-      YAML.safe_load(raw, permitted_classes: [], permitted_symbols: [], aliases: true)
-    end
-
-    alias :parse_yml :parse_yaml
-
-    def parse_json(raw)
-      require "multi_json"
-      MultiJson.load(raw)
-    end
-
-    def parse_toml(raw)
-      require "toml"
-      TOML.load(raw)
+      parse_class = "#{self.class}::#{format.upcase}"
+      raise "unknown format: #{format}" unless ObjectSpace.each_object(Class).find{|c| c.to_s == parse_class }
+      eval(parse_class).parse(raw)
     end
 
   end
-
 end

--- a/lib/config_hound/parser/duplicate_key_error.rb
+++ b/lib/config_hound/parser/duplicate_key_error.rb
@@ -1,0 +1,12 @@
+module ConfigHound
+  class Parser
+    class DuplicateKeyError < ConfigHound::Error
+      attr_reader :duplicates
+
+      def initialize(duplicates)
+        @duplicates = duplicates
+        super(duplicates)
+      end
+    end
+  end
+end

--- a/lib/config_hound/parser/json.rb
+++ b/lib/config_hound/parser/json.rb
@@ -2,13 +2,15 @@ module ConfigHound
   class Parser
     class JSON
       def self.parse(raw)
-        require "ext/duplicate_key_checking_hash"
         require "multi_json"
-        MultiJson.load(raw, object_class: DuplicateKeyCheckingHash)
+        MultiJson.load(raw)
       end
 
       def self.find_duplicate_keys(raw)
-        find_deep_duplicates([], parse(raw))
+        require "ext/duplicate_key_checking_hash"
+        require "multi_json"
+        parsed = MultiJson.load(raw, object_class: DuplicateKeyCheckingHash)
+        find_deep_duplicates([], parsed)
       end
 
       def self.find_deep_duplicates(parents, hash)

--- a/lib/config_hound/parser/json.rb
+++ b/lib/config_hound/parser/json.rb
@@ -2,8 +2,26 @@ module ConfigHound
   class Parser
     class JSON
       def self.parse(raw)
+        require "ext/duplicate_key_checking_hash"
         require "multi_json"
-        MultiJson.load(raw)
+        MultiJson.load(raw, object_class: DuplicateKeyCheckingHash)
+      end
+
+      def self.find_duplicate_keys(raw)
+        find_deep_duplicates([], parse(raw))
+      end
+
+      def self.find_deep_duplicates(parents, hash)
+        return [] unless hash.is_a?(Hash)
+
+        duplicates = hash.duplicate_keys.map{|d| [parents, d].join('.') }
+
+        hash.each do |key, value|
+          next unless value.is_a?(Hash)
+          duplicates += find_deep_duplicates(parents + [key], value)
+        end
+
+        duplicates
       end
     end
   end

--- a/lib/config_hound/parser/json.rb
+++ b/lib/config_hound/parser/json.rb
@@ -1,0 +1,10 @@
+module ConfigHound
+  class Parser
+    class JSON
+      def self.parse(raw)
+        require "multi_json"
+        MultiJson.load(raw)
+      end
+    end
+  end
+end

--- a/lib/config_hound/parser/toml.rb
+++ b/lib/config_hound/parser/toml.rb
@@ -1,0 +1,10 @@
+module ConfigHound
+  class Parser
+    class TOML
+      def self.parse(raw)
+        require "toml"
+        ::TOML.load(raw)
+      end
+    end
+  end
+end

--- a/lib/config_hound/parser/yaml.rb
+++ b/lib/config_hound/parser/yaml.rb
@@ -5,7 +5,36 @@ module ConfigHound
         require "yaml"
         ::YAML.safe_load(raw, permitted_classes: [], permitted_symbols: [], aliases: true)
       end
+
+      def self.find_duplicate_keys(raw)
+        require "psych"
+
+        # Blatantly stolen from https://stackoverflow.com/a/55705853
+        duplicate_keys = []
+
+        validator = ->(node, parent_path) do
+          if node.is_a?(Psych::Nodes::Mapping)
+            children = node.children.each_slice(2)
+            duplicates = children.map { |key_node, _value_node| key_node }.group_by(&:value).select { |_value, nodes| nodes.size > 1 }
+
+            duplicates.each do |key, nodes|
+              duplicate_keys << (parent_path + [key]).join('.')
+            end
+
+            children.each { |key_node, value_node| validator.call(value_node, parent_path + [key_node&.value].compact) }
+          else
+            node.children.to_a.each { |child| validator.call(child, parent_path) }
+          end
+        end
+
+        ast = Psych.parse_stream(raw)
+        validator.call(ast, [])
+
+        duplicate_keys
+      end
     end
+
     class YML < YAML ; end
+
   end
 end

--- a/lib/config_hound/parser/yaml.rb
+++ b/lib/config_hound/parser/yaml.rb
@@ -1,0 +1,11 @@
+module ConfigHound
+  class Parser
+    class YAML
+      def self.parse(raw)
+        require "yaml"
+        ::YAML.safe_load(raw, permitted_classes: [], permitted_symbols: [], aliases: true)
+      end
+    end
+    class YML < YAML ; end
+  end
+end

--- a/lib/config_hound/resource.rb
+++ b/lib/config_hound/resource.rb
@@ -59,8 +59,8 @@ module ConfigHound
       File.extname(uri.path.to_s)[1..-1]
     end
 
-    def load
-      Parser.parse(read, format)
+    def load(options={})
+      Parser.parse(read, format, options)
     end
 
     private

--- a/lib/ext/duplicate_key_checking_hash.rb
+++ b/lib/ext/duplicate_key_checking_hash.rb
@@ -1,0 +1,16 @@
+class DuplicateKeyCheckingHash < Hash
+  attr_reader :duplicate_keys
+
+  def initialize(default=nil)
+    @duplicate_keys = []
+    super(default)
+  end
+
+  def []=(key, value)
+    if has_key?(key)
+      @duplicate_keys << key
+    end
+
+    super(key, value)
+  end
+end

--- a/spec/features/duplicate_keys_spec.rb
+++ b/spec/features/duplicate_keys_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+require "config_hound"
+
+describe ConfigHound, "duplicate_keys" do
+
+  let(:config) { ConfigHound.load(resource, options) }
+
+  given_resource "config.yaml", %{
+    foo:
+      bar: baz
+      bar: qux
+  }
+
+  given_resource "config.json", %[
+    { "foo": { "bar": "baz", "bar": "qux" } }
+  ]
+
+  %w(yaml json).each do |type|
+
+    context "in #{type}" do
+
+      let(:resource) { "config.#{type}" }
+
+      context "with duplicate keys allowed" do
+        let(:options) { { allow_duplicate_keys: true } }
+
+        it "takes the later key" do
+          expect(config).to eq("foo" => { "bar" => "qux" })
+        end
+      end
+
+      context "with duplicate keys disabled" do
+        let(:options) { { allow_duplicate_keys: false } }
+
+        it "raises a DuplicateKeyError" do
+          expect { config }.to raise_error(ConfigHound::Parser::DuplicateKeyError)
+        end
+
+        it "tells you which key is duplicated" do
+          expect { config }.to raise_error(ConfigHound::Parser::DuplicateKeyError, /foo\.bar/)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
We want a way to raise errors when there are duplicate keys in the config. This is becoming a bigger problem for us as our yaml files get bigger and bigger, or spread out across hundreds of files. An alternative to this would be to use a yaml / json lint program prior to using them in `ConfigHound`.

Some challenges here so far are that `SafeYaml` doesn't easily support a custom `object_class` at `load` time, as far as I can tell. I think we'd need to monkey patch something down in the `Psych` code, or look into other yaml parsers.

The toml parser we're using at the moment already hard fails on duplicate keys, so I feel implementing this feature for that might be quite troublesome, as we are setting the default to allow duplicates for backwards compatibility, and this would raise the question around breaking that for toml, if it was even possible to implement.